### PR TITLE
Handle format errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "xlstream",
-  "version": "2.5.3",
+  "name": "watershedclimate/xlstream",
+  "version": "2.5.10",
   "description": "Turns XLSX into a readable stream.",
   "main": "lib/index",
   "types": "lib/index",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "watershedclimate/xlstream",
+  "name": "@watershedclimate/xlstream",
   "version": "2.5.10",
   "description": "Turns XLSX into a readable stream.",
   "main": "lib/index",

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,8 @@ function getTransform(formats: (string | number)[], strings: string[], dict?: IM
                     arr[index] = value;
                     obj[column] = value;
                     if (formatId) {
+                      // Watershed patch: This try/catch block is to prevent unhandled rejection errors when formatting fails.
+                      try {
                         let numFormat = formats[formatId];
                         if (numberFormat && numberFormat === 'excel' && typeof numFormat === 'number' && excelNumberFormat[numFormat]) {
                             numFormat = excelNumberFormat[numFormat];
@@ -146,6 +148,11 @@ function getTransform(formats: (string | number)[], strings: string[], dict?: IM
                             value = ssf.format(numFormat, value);
                         }
                         value = formatNumericValue(type, value);
+                      } catch (err) {
+                        // Formatting errors should not generate unhandled rejection errors.
+                        done(err);
+                        return;
+                      }
                     }
                     if (dict?.[lastReceivedRow]?.[column]) {
                         dict[lastReceivedRow][column].value.formatted = value;


### PR DESCRIPTION
Unhandled errors in this code cause the stream processing to fail and no event to come back to our client handler in RoboCleaner.ts This results in timeouts in the calling code. This patch adds error handling.

Testing: Added a unit tests for this case to RoboCleaner and it now returns correctly.